### PR TITLE
Make the Windows auto-update survive its own hand-off

### DIFF
--- a/internal/install/jetbrainsplugin.go
+++ b/internal/install/jetbrainsplugin.go
@@ -464,7 +464,14 @@ func extractWithCloseRetry(zipPath, pluginsDir, label string) error {
 		}
 		fmt.Printf("\n  %s is open, so Windows won't let us replace its plugin files.\n", label)
 		fmt.Printf("  Close %s completely, then press Enter to retry (or type 'n' to skip): ", label)
-		line, _ := reader.ReadString('\n')
+		line, rerr := reader.ReadString('\n')
+		if rerr != nil {
+			// Nothing left to read: stdin was closed, or it is the null device,
+			// which Windows reports as a character device so stdinInteractive
+			// cannot tell it apart from a console. Without this the empty line
+			// matches no case and the loop reprints the prompt forever.
+			return err
+		}
 		switch strings.ToLower(strings.TrimSpace(line)) {
 		case "n", "no", "s", "skip":
 			return err

--- a/internal/install/stdio_other.go
+++ b/internal/install/stdio_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package install
+
+import "os"
+
+// usableStdHandle reports whether f can be handed to a child process as one of
+// its standard handles. Only Windows can hand back an unusable std handle from
+// a console-less process (see stdio_windows.go); on Unix an open file
+// descriptor is always inheritable, and a closed one is a plain nil file.
+func usableStdHandle(f *os.File) bool {
+	return f != nil
+}

--- a/internal/install/stdio_test.go
+++ b/internal/install/stdio_test.go
@@ -1,0 +1,83 @@
+package install
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestChildOutput_DropsUnusableFile(t *testing.T) {
+	// A nil *os.File is what a console-less process's std handle degrades to
+	// once usableStdHandle rejects it. It must never reach os/exec, which would
+	// hand CreateProcess a std handle it refuses.
+	if got := childOutput((*os.File)(nil)); got != io.Discard {
+		t.Errorf("nil *os.File = %T, want io.Discard", got)
+	}
+	if got := childOutput(nil); got != io.Discard {
+		t.Errorf("nil writer = %T, want io.Discard", got)
+	}
+}
+
+func TestChildOutput_PassesOrdinaryWriterThrough(t *testing.T) {
+	var buf bytes.Buffer
+	if got := childOutput(&buf); got != io.Writer(&buf) {
+		t.Errorf("ordinary writer was replaced with %T", got)
+	}
+	// A usable *os.File stays inherited, so an interactive `blamely update`
+	// keeps writing straight to its console. A real temp file rather than
+	// os.Stdout: on Windows the test binary may itself be running without
+	// standard handles, and then os.Stdout is exactly the unusable case the
+	// other test covers.
+	f, err := os.CreateTemp(t.TempDir(), "out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if got := childOutput(f); got != io.Writer(f) {
+		t.Errorf("usable *os.File was replaced with %T", got)
+	}
+}
+
+// TestRunInstaller_GivesChildNoStdin is the regression guard for the Windows
+// auto-update failure: runInstaller used to assign os.Stdin/os.Stdout/os.Stderr
+// to the child, so a daemon started with CREATE_NO_WINDOW passed on std handles
+// CreateProcess rejected with ERROR_NOT_SUPPORTED. The child must get an empty
+// stdin and send its output to the writer we asked for.
+func TestRunInstaller_GivesChildNoStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	var out bytes.Buffer
+	// `cat` drains stdin: with no stdin it sees EOF at once instead of blocking.
+	if err := runInstaller("/bin/sh", &out, "-c", "cat; echo done-$?"); err != nil {
+		t.Fatalf("runInstaller: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "done-0" {
+		t.Errorf("child output = %q, want %q (a non-empty or blocking stdin would change this)", got, "done-0")
+	}
+}
+
+func TestRunInstaller_MergesStderrIntoOut(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	var out bytes.Buffer
+	err := runInstaller("/bin/sh", &out, "-c", "echo to-stderr >&2; exit 3")
+	if err == nil {
+		t.Fatal("want the child's non-zero exit reported")
+	}
+	// The installer's diagnosis usually arrives on stderr; losing it is what
+	// left the daemon's auto-update failure with nothing but an exit status.
+	if !strings.Contains(out.String(), "to-stderr") {
+		t.Errorf("stderr missing from captured output: %q", out.String())
+	}
+}
+
+func TestUsableStdHandle_NilIsUnusable(t *testing.T) {
+	if usableStdHandle(nil) {
+		t.Error("a nil file must never be offered to a child process")
+	}
+}

--- a/internal/install/stdio_windows.go
+++ b/internal/install/stdio_windows.go
@@ -1,0 +1,31 @@
+package install
+
+import (
+	"os"
+	"syscall"
+)
+
+// usableStdHandle reports whether f's underlying HANDLE can be handed to a child
+// process as one of its standard handles.
+//
+// A Windows process started without standard handles — the Blamely daemon is
+// launched with CREATE_NO_WINDOW, and a Scheduled Task or a Startup shortcut
+// gives its child none either — still has os.Stdin/os.Stdout/os.Stderr: the os
+// package wraps whatever GetStdHandle returned, which in that case is NULL or
+// INVALID_HANDLE_VALUE. Passing one of those to exec.Cmd is not inert:
+// syscall.StartProcess sets STARTF_USESTDHANDLES unconditionally and duplicates
+// each handle it considers non-zero. INVALID_HANDLE_VALUE is the
+// current-process pseudo-handle, so the duplicate SUCCEEDS and CreateProcess is
+// then handed a PROCESS handle where it expects a file or pipe — which fails
+// with ERROR_NOT_SUPPORTED ("İstek desteklenmiyor" on a Turkish install).
+//
+// That is what broke the daemon's auto-update: the staged binary ran fine for
+// the `--version` sanity gate (CombinedOutput uses pipes) and then failed to
+// start for the install hand-off moments later, on the same path.
+func usableStdHandle(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	h := syscall.Handle(f.Fd())
+	return h != 0 && h != syscall.InvalidHandle
+}

--- a/internal/install/update.go
+++ b/internal/install/update.go
@@ -85,13 +85,47 @@ type UpdateResult struct {
 	Reason  string
 }
 
-// runInstaller executes the staged binary's own `install`. A package var so
-// tests can assert the hand-off without running a real install (the same seam
-// pattern as tools.cursorHomeDir).
-var runInstaller = func(bin string, args ...string) error {
+// runInstaller executes the staged binary's own `install`, sending its output to
+// out. A package var so tests can assert the hand-off without running a real
+// install (the same seam pattern as tools.cursorHomeDir).
+//
+// It deliberately does NOT inherit this process's own standard handles, which is
+// what it used to do:
+//
+//   - stdin is left nil (the child gets NUL / /dev/null). `blamely install` has
+//     prompts, but none that a hand-off should answer: the JetBrains
+//     plugin-locked retry is skipped when stdin is not interactive, and the
+//     uninstall blocker prompt treats a read error as "no". Inheriting ours
+//     bought nothing and could only fail.
+//   - stdout/stderr follow out, and an out that is an unusable *os.File is
+//     dropped rather than passed on. A console-less caller — the daemon's
+//     auto-update, or `blamely update` from a Scheduled Task — otherwise hands
+//     CreateProcess a std handle it rejects with ERROR_NOT_SUPPORTED, failing
+//     the hand-off for a staged binary that had just run fine. See
+//     usableStdHandle in stdio_windows.go for the mechanism.
+var runInstaller = func(bin string, out io.Writer, args ...string) error {
 	cmd := exec.Command(bin, args...)
-	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	// One writer value for both streams, deliberately: os/exec gives the child a
+	// single pipe when Stdout and Stderr are interface-equal, so the two streams
+	// interleave into one goroutine's writes. Assigning two separately-derived
+	// values would make os/exec copy them concurrently and race any writer that
+	// is not safe for concurrent use.
+	w := childOutput(out)
+	cmd.Stdout, cmd.Stderr = w, w
 	return cmd.Run()
+}
+
+// childOutput adapts out for use as a child process's stdout/stderr. os/exec
+// inherits an *os.File's handle directly and pipes anything else, so this is
+// also the seam that decides which of those two the child gets.
+func childOutput(out io.Writer) io.Writer {
+	if out == nil {
+		return io.Discard
+	}
+	if f, ok := out.(*os.File); ok && !usableStdHandle(f) {
+		return io.Discard
+	}
+	return out
 }
 
 // executablePath resolves this process's own binary for the "am I the installed
@@ -408,21 +442,51 @@ func Update(ctx context.Context, opts UpdateOptions) (UpdateResult, error) {
 		res.To = normalizeVersion(lastField(gotVer))
 	}
 
-	// 8. Hand off to the NEW binary's own installer. It already replaces a
-	// running binary safely (placeBinary renames a locked destination aside and
-	// rolls back on failure), re-registers every tool hook idempotently, and
-	// restarts the daemon agent — no need to reimplement any of that here.
+	// 8. Put the new binary at the stable path OURSELVES, by rename.
+	//
+	// Everything that invokes blamely — each tool's PostToolUse hook, the global
+	// git hook, the autostart entry and the Windows keepalive task — spells that
+	// path literally and none of them is rewritten by an update. So swapping the
+	// file behind it IS the update: nothing else has to succeed for the new
+	// version to take over the next time the daemon starts.
+	//
+	// placeBinary makes that safe on Windows, where a running image cannot be
+	// overwritten but CAN be renamed: it moves the locked destination aside as
+	// <name>.old-<ts>, puts the new one in place, and rolls back if that fails.
+	// The old process keeps running from the renamed file until it restarts.
+	//
+	// This runs here rather than inside the hand-off below because the hand-off
+	// is a CHILD of this process, and `blamely install` kills this process —
+	// with its tree — on Windows. Anything that must survive for the update to
+	// count cannot depend on that child finishing.
+	installedPath, err := CopyBinary(binPath)
+	if err != nil {
+		res.Reason = "could not replace the installed binary"
+		return res, fmt.Errorf("install %s failed (the previous version is still in place): %w", res.To, err)
+	}
+	staged = true
+	_ = os.RemoveAll(stage)
+	res.Updated = true
+
+	// 9. Hand the REST off to the now-installed binary: re-register every tool
+	// hook (a new release may add one) and restart the daemon agent so the new
+	// version takes over immediately instead of at the next start.
+	//
+	// Best-effort by design. Step 8 already updated the version, so a failure
+	// here costs a hook refresh and an immediate restart — not the update. On
+	// Windows this step routinely takes the daemon (and, through the same kill,
+	// itself) down; the keepalive task then revives the daemon from the stable
+	// path, which now holds the new binary.
 	args := []string{"install"}
 	if !opts.WithPlugins {
 		args = append(args, "--skip-plugins")
 	}
-	if err := runInstaller(binPath, args...); err != nil {
-		return res, fmt.Errorf("install %s failed (the previous version is still in place; retry with %s): %w", res.To, binPath, err)
+	if err := runInstaller(installedPath, out, args...); err != nil {
+		res.Reason = "installed; the post-install step did not finish"
+		fmt.Fprintf(out, "blamely %s is in place, but finishing the install failed: %v\n"+
+			"Hooks keep working through the unchanged path. Run `blamely install` to refresh them.\n",
+			res.To, err)
 	}
-	staged = true
-	_ = os.RemoveAll(stage)
-
-	res.Updated = true
 	return res, nil
 }
 

--- a/internal/install/update_test.go
+++ b/internal/install/update_test.go
@@ -8,7 +8,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -21,7 +23,7 @@ import (
 
 // stubInstaller replaces the hand-off for one test and restores the real one
 // afterwards, so a later test can't accidentally run against a nil installer.
-func stubInstaller(t *testing.T, fn func(bin string, args ...string) error) {
+func stubInstaller(t *testing.T, fn func(bin string, out io.Writer, args ...string) error) {
 	t.Helper()
 	prev := runInstaller
 	runInstaller = fn
@@ -271,10 +273,20 @@ func TestUpdate_DownloadsVerifiesAndHandsOff(t *testing.T) {
 	})
 	pinUpdateAPI(t, srv.URL)
 
+	installed, err := InstalledBinaryPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var gotBin string
 	var gotArgs []string
-	stubInstaller(t, func(bin string, args ...string) error {
+	var installedAtHandOff string
+	stubInstaller(t, func(bin string, _ io.Writer, args ...string) error {
 		gotBin, gotArgs = bin, args
+		// The whole point of placing the binary before the hand-off: by the time
+		// the hand-off runs, the stable path ALREADY holds the new version.
+		body, _ := os.ReadFile(installed)
+		installedAtHandOff = string(body)
 		return nil
 	})
 
@@ -285,13 +297,74 @@ func TestUpdate_DownloadsVerifiesAndHandsOff(t *testing.T) {
 	if !res.Updated || res.To != "1.8.0" {
 		t.Fatalf("result = %+v, want Updated with To=1.8.0", res)
 	}
-	// The hand-off must run the STAGED binary's own installer, skipping plugins.
-	wantPrefix := filepath.Join(binDir, updateStagingPrefix+"v1.8.0")
-	if !strings.HasPrefix(gotBin, wantPrefix) {
-		t.Errorf("handed off %q, want a binary under %q", gotBin, wantPrefix)
+	if !strings.Contains(installedAtHandOff, "1.8.0") {
+		t.Errorf("stable path did not hold 1.8.0 when the hand-off ran:\n%s", installedAtHandOff)
+	}
+	// The hand-off runs the INSTALLED binary, not the staged copy: the staging
+	// dir is gone by then, and running the installed one lets its CopyBinary
+	// no-op instead of copying the file a second time.
+	if gotBin != installed {
+		t.Errorf("handed off %q, want the installed binary %q", gotBin, installed)
 	}
 	if strings.Join(gotArgs, " ") != "install --skip-plugins" {
 		t.Errorf("args = %v, want [install --skip-plugins]", gotArgs)
+	}
+	// Staging is consumed once the binary is placed.
+	if _, serr := os.Stat(filepath.Join(binDir, updateStagingPrefix+"v1.8.0")); !os.IsNotExist(serr) {
+		t.Errorf("staging dir survived a successful update: %v", serr)
+	}
+}
+
+// TestUpdate_BinaryIsUpdatedEvenWhenHandOffFails is the reason step 8 places the
+// binary itself. The hand-off is a child of this process and `blamely install`
+// kills this process's tree on Windows, so it cannot be the step the update
+// depends on. A failing hand-off must still leave the machine on the NEW
+// version — hooks and the autostart entry all point at the stable path, which
+// now holds it.
+func TestUpdate_BinaryIsUpdatedEvenWhenHandOffFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("see TestUpdate_DownloadsVerifiesAndHandsOff")
+	}
+	pinInstalledSelf(t)
+
+	archive := buildArchive(t, "blamely_v1.8.0_"+runtime.GOOS+"_"+runtime.GOARCH, fakeBinary("1.8.0"))
+	asset := platformAsset("v1.8.0")
+	sums := fmt.Sprintf("%s  %s\n", sha256Hex(archive), asset)
+	srv := releaseServer(t, "/releases/latest", "v1.8.0", map[string][]byte{
+		asset:        archive,
+		"SHA256SUMS": []byte(sums),
+	})
+	pinUpdateAPI(t, srv.URL)
+
+	stubInstaller(t, func(bin string, _ io.Writer, args ...string) error {
+		return errors.New("fork/exec: the request is not supported")
+	})
+
+	var out bytes.Buffer
+	res, err := Update(context.Background(), UpdateOptions{Current: "1.7.0", Out: &out})
+	if err != nil {
+		t.Fatalf("a failed hand-off must not fail the update: %v", err)
+	}
+	if !res.Updated || res.To != "1.8.0" {
+		t.Fatalf("result = %+v, want Updated with To=1.8.0", res)
+	}
+	if res.Reason == "" {
+		t.Error("a partial completion must be reported in Reason")
+	}
+
+	installed, err := InstalledBinaryPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(installed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "1.8.0") {
+		t.Errorf("the installed binary is not the new version:\n%s", body)
+	}
+	if !strings.Contains(out.String(), "`blamely install`") {
+		t.Errorf("the user was not told how to finish the install:\n%s", out.String())
 	}
 }
 
@@ -313,7 +386,7 @@ func TestUpdate_ChecksumMismatchAborts(t *testing.T) {
 	pinUpdateAPI(t, srv.URL)
 
 	called := false
-	stubInstaller(t, func(bin string, args ...string) error { called = true; return nil })
+	stubInstaller(t, func(bin string, _ io.Writer, args ...string) error { called = true; return nil })
 
 	res, err := Update(context.Background(), UpdateOptions{Current: "1.7.0", Out: &bytes.Buffer{}})
 	if err == nil {
@@ -339,7 +412,7 @@ func TestUpdate_NoNewerVersionIsNoop(t *testing.T) {
 	pinUpdateAPI(t, srv.URL)
 
 	called := false
-	stubInstaller(t, func(bin string, args ...string) error { called = true; return nil })
+	stubInstaller(t, func(bin string, _ io.Writer, args ...string) error { called = true; return nil })
 
 	res, err := Update(context.Background(), UpdateOptions{Current: "1.7.0", Out: &bytes.Buffer{}})
 	if err != nil {
@@ -360,7 +433,7 @@ func TestUpdate_RefusesWhenNotInstalledCopy(t *testing.T) {
 	// has to be path identity.
 	fakeHomeDir(t)
 	called := false
-	stubInstaller(t, func(bin string, args ...string) error { called = true; return nil })
+	stubInstaller(t, func(bin string, _ io.Writer, args ...string) error { called = true; return nil })
 
 	res, err := Update(context.Background(), UpdateOptions{Current: "1.7.0", Out: &bytes.Buffer{}})
 	if err == nil {


### PR DESCRIPTION
The daemon's auto-update fails on Windows with `fork/exec ...: the request is not supported` (ERROR_NOT_SUPPORTED), leaving the machine on the old version indefinitely. Reported from a Turkish install as `İstek desteklenmiyor`:

```
update install failed: install 1.8.1 failed (the previous version is still in place;
retry with C:\Users\...\.blamely\bin\.update-v1.8.1\blamely.exe):
fork/exec C:\Users\...\.blamely\bin\.update-v1.8.1\blamely.exe: İstek desteklenmiyor.
```

## Why it happens

The staged binary ran fine seconds earlier, on the same path, for the `--version` sanity gate. The difference is how each child is started:

| | stdin | stdout/stderr |
|---|---|---|
| `binaryVersion` (works) | nil → NUL | `CombinedOutput()` → **pipe** |
| `runInstaller` (fails) | `os.Stdin` | `os.Stdout` / `os.Stderr` |

The daemon is launched with `CREATE_NO_WINDOW` (`startDaemonNow`), and a Scheduled Task or Startup shortcut gives it no standard handles either — but the `os` package still wraps whatever `GetStdHandle` returned. `syscall.StartProcess` sets `STARTF_USESTDHANDLES` unconditionally and duplicates every handle it considers non-zero; `INVALID_HANDLE_VALUE` is the current-process pseudo-handle, so the duplicate **succeeds** and `CreateProcess` is handed a PROCESS handle where it expects a file or pipe.

## The change

`runInstaller` no longer inherits this process's standard handles: stdin stays nil (the installer never reads it — `BLAMELY_INSTALL_YES` covers its one prompt) and stdout/stderr follow the caller's `Out`, with an unusable `*os.File` dropped rather than passed on (`usableStdHandle`, new `stdio_windows.go` / `stdio_other.go` pair, matching the existing `bin_windows.go` / `bin_other.go` convention).

`Update` also stops depending on that hand-off for the update itself. It now places the new binary at the stable path **first**, by rename — `CopyBinary`/`placeBinary` already move a locked Windows image aside as `<name>.old-<ts>` and roll back on failure. Every caller of blamely spells that stable path (each tool hook, the git hook, the autostart entry, the keepalive task) and none is rewritten by an update, so swapping the file behind it *is* the update; nothing else has to succeed for the new version to take over at the next start. The hand-off keeps its remaining job — refreshing hooks, restarting the agent — as best effort.

That ordering matters beyond this bug: the hand-off is a CHILD of the daemon, and `blamely install` kills the daemon's process tree on Windows (`killRunningDaemon` → `taskkill /F /T`), so the installer is inside the tree it terminates. With the binary placed first, that self-kill costs an immediate restart (the keepalive revives it within 15 min) instead of the whole update.

The sanity gate still runs before any of it, so what gets placed is known to execute and report the expected version.

## Tests

Five new cases in `stdio_test.go` plus a rewritten hand-off test: the child gets an empty stdin, stderr reaches the caller's writer, an unusable `*os.File` is dropped, the stable path already holds the new version when the hand-off runs, and `Update` still reports success with the binary updated when the hand-off fails.

`go build ./...`, `go vet ./...` and `internal/install` pass on this branch alone (branched from `main`, single commit).

## Not verified on Windows

I could not reproduce on a Windows host — the diagnosis is from the code path plus `syscall/exec_windows.go`, and the fix removes the whole class by never handing a console-less parent's handles to the child. Worth a run on a real machine before merging.