### PR TITLE
Stop subprocesses flashing a console window on Windows

### DIFF
--- a/internal/gitnotes/attribute.go
+++ b/internal/gitnotes/attribute.go
@@ -17,6 +17,8 @@ import (
 	"github.com/blamely/blamely/internal/gitutil"
 	"github.com/blamely/blamely/internal/store"
 	"github.com/blamely/blamely/internal/tools"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 const NotesRef = "refs/notes/blamely"
@@ -1523,7 +1525,7 @@ func buildNote(db *store.DB, repoPath, sha string, commitNanos int64, added []Ad
 // file as it exists at sha, hashed the same way edits record added lines
 // (TrimRight "\r", blank lines skipped). nil on any git error.
 func committedLineSHAs(repoPath, sha, path string) map[string]int {
-	out, err := exec.Command("git", "-C", repoPath, "show", sha+":"+path).Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "show", sha+":"+path)).Output()
 	if err != nil {
 		return nil
 	}
@@ -1907,7 +1909,7 @@ func nullInt64(n sql.NullInt64) int64 {
 }
 
 func writeNote(repoPath, sha string, body []byte) error {
-	cmd := exec.Command("git", "-C", repoPath, "notes", "--ref="+NotesRef, "add", "-f", "-F", "-", sha)
+	cmd := procattr.Hide(exec.Command("git", "-C", repoPath, "notes", "--ref="+NotesRef, "add", "-f", "-F", "-", sha))
 	cmd.Stdin = strings.NewReader(string(body))
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/gitnotes/attribution_gitops.go
+++ b/internal/gitnotes/attribution_gitops.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/blamely/blamely/internal/authorship"
 	"github.com/blamely/blamely/internal/gitutil"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // Git-op robustness for Attribution (docs/attribution-v2-design.md §8, Phase 5).
@@ -32,11 +34,11 @@ func ensureNotesFollowRewrites(repoPath string) {
 	if !authorship.Enabled() {
 		return
 	}
-	if out, err := exec.Command("git", "-C", repoPath, "config", "--get", "notes.rewriteMode").Output(); err != nil ||
+	if out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "config", "--get", "notes.rewriteMode")).Output(); err != nil ||
 		strings.TrimSpace(string(out)) != "overwrite" {
-		_ = exec.Command("git", "-C", repoPath, "config", "notes.rewriteMode", "overwrite").Run()
+		_ = procattr.Hide(exec.Command("git", "-C", repoPath, "config", "notes.rewriteMode", "overwrite")).Run()
 	}
-	out, err := exec.Command("git", "-C", repoPath, "config", "--get-all", "notes.rewriteRef").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "config", "--get-all", "notes.rewriteRef")).Output()
 	if err == nil {
 		for _, l := range strings.Split(string(out), "\n") {
 			if strings.TrimSpace(l) == NotesRef {
@@ -44,7 +46,7 @@ func ensureNotesFollowRewrites(repoPath string) {
 			}
 		}
 	}
-	_ = exec.Command("git", "-C", repoPath, "config", "--add", "notes.rewriteRef", NotesRef).Run()
+	_ = procattr.Hide(exec.Command("git", "-C", repoPath, "config", "--add", "notes.rewriteRef", NotesRef)).Run()
 }
 
 // attributionShouldSkip reports whether to skip (re)attribution because a history-

--- a/internal/gitnotes/attribution_merge.go
+++ b/internal/gitnotes/attribution_merge.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/blamely/blamely/internal/authorship"
 	"github.com/blamely/blamely/internal/config"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // restrictMergeToResolution narrows a MERGE commit's added lines to the conflict
@@ -24,7 +26,7 @@ func restrictMergeToResolution(repoPath, sha string, change *CommitChange) {
 	if change == nil || !authorship.Enabled() {
 		return
 	}
-	out, err := exec.Command("git", "-C", repoPath, "rev-parse", "-q", "--verify", sha+"^2").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "rev-parse", "-q", "--verify", sha+"^2")).Output()
 	if err != nil {
 		return // not a merge (no second parent)
 	}

--- a/internal/gitnotes/attribution_parent.go
+++ b/internal/gitnotes/attribution_parent.go
@@ -3,13 +3,15 @@ package gitnotes
 import (
 	"os/exec"
 	"strings"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // commitParentSHA returns sha's first parent, or "" for a root commit / on error.
 // The Attribution flips key the working log by the commit's PARENT (HEAD at edit
 // time), so they resolve it through here.
 func commitParentSHA(repoPath, sha string) string {
-	out, err := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "-q", sha+"^").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "-q", sha+"^")).Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/gitnotes/attribution_replay.go
+++ b/internal/gitnotes/attribution_replay.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"github.com/blamely/blamely/internal/gitutil"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 type replayKind int
@@ -93,7 +95,7 @@ func replayFromMessage(msg string) replayCtx {
 }
 
 func commitMessage(repoPath, sha string) string {
-	out, err := exec.Command("git", "-C", repoPath, "log", "-1", "--format=%B", sha).Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "log", "-1", "--format=%B", sha)).Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/gitnotes/attribution_seed.go
+++ b/internal/gitnotes/attribution_seed.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/blamely/blamely/internal/authorship"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // SeedCommittedWorkingLog writes a working log for relPath at (branch, baseSHA) that
@@ -44,7 +46,7 @@ func SeedCommittedWorkingLog(repoPath, branch, baseSHA, relPath string) error {
 // than one `git notes show` per commit — the per-commit spawns were the dominant cost
 // for files with long history, slow enough on Windows to trip the editor's timeout.
 func committedAuthorsByLine(repoPath, baseSHA, relPath string) []authorship.Author {
-	out, err := exec.Command("git", "-C", repoPath, "blame", "--porcelain", baseSHA, "--", relPath).Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "blame", "--porcelain", baseSHA, "--", relPath)).Output()
 	if err != nil {
 		return nil
 	}
@@ -139,7 +141,7 @@ func ShowFileAt(repoPath, sha, relPath string) (string, bool) {
 }
 
 func showFileAt(repoPath, sha, relPath string) (string, bool) {
-	out, err := exec.Command("git", "-C", repoPath, "show", sha+":"+relPath).Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "show", sha+":"+relPath)).Output()
 	if err != nil {
 		return "", false
 	}
@@ -150,7 +152,7 @@ func showFileAt(repoPath, sha, relPath string) (string, bool) {
 // show`). Used where exactly one note is needed (e.g. the inherited note on amend);
 // the seeding path uses prefetchSeedNotes to batch many.
 func loadNoteForSeed(repoPath, sha string) *Note {
-	out, err := exec.Command("git", "-C", repoPath, "notes", "--ref="+NotesRef, "show", sha).Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "notes", "--ref="+NotesRef, "show", sha)).Output()
 	if err != nil {
 		return nil
 	}
@@ -172,7 +174,7 @@ func prefetchSeedNotes(repoPath string, shas map[string]bool) map[string]*Note {
 	if len(shas) == 0 {
 		return notes
 	}
-	listOut, err := exec.Command("git", "-C", repoPath, "notes", "--ref="+NotesRef, "list").Output()
+	listOut, err := procattr.Hide(exec.Command("git", "-C", repoPath, "notes", "--ref="+NotesRef, "list")).Output()
 	if err != nil {
 		return notes // no notes ref / error → everything resolves to Human
 	}
@@ -211,7 +213,7 @@ func batchCatFileBlobs(repoPath string, objs []string) map[string][]byte {
 	if len(objs) == 0 {
 		return res
 	}
-	cmd := exec.Command("git", "-C", repoPath, "cat-file", "--batch")
+	cmd := procattr.Hide(exec.Command("git", "-C", repoPath, "cat-file", "--batch"))
 	cmd.Stdin = strings.NewReader(strings.Join(objs, "\n") + "\n")
 	out, err := cmd.Output()
 	if err != nil && len(out) == 0 {
@@ -260,7 +262,7 @@ func isHex40(s string) bool {
 // only changed lines (not every committed line). Empty/no diff → empty set.
 func UncommittedAddedLines(repoPath, relPath string) map[int]bool {
 	set := map[int]bool{}
-	out, err := exec.Command("git", "-C", repoPath, "diff", "HEAD", "--unified=0", "--no-color", "--", relPath).Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "diff", "HEAD", "--unified=0", "--no-color", "--", relPath)).Output()
 	if err != nil {
 		return set
 	}
@@ -361,7 +363,7 @@ func UntrackedFiles(repoPath string) map[string]bool {
 // to "every line changed" instead of showing a blank gutter. `git ls-files --others
 // --exclude-standard` lists exactly the untracked-and-not-ignored paths.
 func IsUntracked(repoPath, relPath string) bool {
-	out, err := exec.Command("git", "-C", repoPath, "ls-files", "--others", "--exclude-standard", "--", relPath).Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "ls-files", "--others", "--exclude-standard", "--", relPath)).Output()
 	if err != nil {
 		return false
 	}

--- a/internal/gitnotes/attribution_worktree.go
+++ b/internal/gitnotes/attribution_worktree.go
@@ -9,13 +9,15 @@ import (
 	"github.com/blamely/blamely/internal/config"
 	"github.com/blamely/blamely/internal/gitutil"
 	"github.com/blamely/blamely/internal/store"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // DiffWorkingTree diffs the working tree against HEAD (tracked changes, staged +
 // unstaged) and parses it like DiffCommit, so the CURRENT uncommitted change can be
 // attributed and shown by `blamely stats` before a commit exists.
 func DiffWorkingTree(repoPath string) (*CommitChange, error) {
-	cmd := exec.Command("git", "-C", repoPath, "diff", "--unified=0", "--no-color", "-M", "HEAD")
+	cmd := procattr.Hide(exec.Command("git", "-C", repoPath, "diff", "--unified=0", "--no-color", "-M", "HEAD"))
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err

--- a/internal/gitnotes/diff.go
+++ b/internal/gitnotes/diff.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/blamely/blamely/internal/config"
 	"github.com/blamely/blamely/internal/tools"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // linesSimilar reports whether a removed line (del) and an added line (add) at
@@ -92,10 +94,10 @@ const (
 // copy map for files git detected as copy-with-modifications.
 type CommitChange struct {
 	Added       []AddedLine
-	Deleted     map[string][]DeletedLine   // pre-commit path → deleted lines (pre-image)
-	Renames     map[string]string          // post-commit path → pre-commit path (renamed)
-	Copies      map[string]string          // post-commit path → pre-commit path (copied)
-	FileChanges map[string]FileChangeType  // post-commit path → file-level change kind
+	Deleted     map[string][]DeletedLine  // pre-commit path → deleted lines (pre-image)
+	Renames     map[string]string         // post-commit path → pre-commit path (renamed)
+	Copies      map[string]string         // post-commit path → pre-commit path (copied)
+	FileChanges map[string]FileChangeType // post-commit path → file-level change kind
 }
 
 // DeletedCount returns the per-file count derived from Deleted line numbers.
@@ -145,7 +147,7 @@ func DiffCommit(repoPath, sha string) (*CommitChange, error) {
 		}
 		args = []string{"-C", repoPath, "diff", "--unified=0", "--no-color", "-M", emptyTree, sha}
 	}
-	cmd := exec.Command("git", args...)
+	cmd := procattr.Hide(exec.Command("git", args...))
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -469,7 +471,7 @@ func parseHunkHeaderBothSides(s string) (delStart, addStart int, ok bool) {
 }
 
 func parentSHA(repoPath, sha string) (string, bool, error) {
-	out, err := exec.Command("git", "-C", repoPath, "rev-parse", sha+"^").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "rev-parse", sha+"^")).Output()
 	if err != nil {
 		// First commit has no parent.
 		return "", false, nil
@@ -478,7 +480,7 @@ func parentSHA(repoPath, sha string) (string, bool, error) {
 }
 
 func emptyTreeSHA(repoPath string) (string, error) {
-	out, err := exec.Command("git", "-C", repoPath, "hash-object", "-t", "tree", "/dev/null").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "hash-object", "-t", "tree", "/dev/null")).Output()
 	if err != nil {
 		// Fallback to the well-known empty tree SHA-1 hash.
 		return "4b825dc642cb6eb9a060e54bf8d69288fbee4904", nil
@@ -489,7 +491,7 @@ func emptyTreeSHA(repoPath string) (string, error) {
 // CommitMessage returns the full commit message body (subject + body) of sha.
 // Empty string on error so callers can tolerate detached/missing state.
 func CommitMessage(repoPath, sha string) string {
-	out, err := exec.Command("git", "-C", repoPath, "show", "-s", "--format=%B", sha).Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "show", "-s", "--format=%B", sha)).Output()
 	if err != nil {
 		return ""
 	}
@@ -501,7 +503,7 @@ func CommitMessage(repoPath, sha string) string {
 // produced. This is called immediately after the commit, while HEAD still
 // points to the new commit on the recording branch.
 func BranchName(repoPath string) string {
-	out, err := exec.Command("git", "-C", repoPath, "branch", "--show-current").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "branch", "--show-current")).Output()
 	if err != nil {
 		return ""
 	}
@@ -509,7 +511,7 @@ func BranchName(repoPath string) string {
 }
 
 func CommitTimestampNanos(repoPath, sha string) (int64, error) {
-	out, err := exec.Command("git", "-C", repoPath, "show", "-s", "--format=%ct", sha).Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "show", "-s", "--format=%ct", sha)).Output()
 	if err != nil {
 		return 0, fmt.Errorf("git show: %w", err)
 	}
@@ -533,7 +535,7 @@ func lastFileTouchNanos(repoPath, ref, relPath string) int64 {
 	if ref == "" || relPath == "" {
 		return 0
 	}
-	out, err := exec.Command("git", "-C", repoPath, "log", "-1", "--format=%ct", ref, "--", relPath).Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoPath, "log", "-1", "--format=%ct", ref, "--", relPath)).Output()
 	if err != nil {
 		return 0
 	}

--- a/internal/gitutil/branch.go
+++ b/internal/gitutil/branch.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // BranchName returns the short name of the currently checked-out branch for the
@@ -12,7 +14,7 @@ import (
 // or git fails — callers treat "" as "no branch" (a detached/unknown session).
 func BranchName(p string) string {
 	dir := repoDir(p)
-	out, err := exec.Command("git", "-C", dir, "symbolic-ref", "--quiet", "--short", "HEAD").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", dir, "symbolic-ref", "--quiet", "--short", "HEAD")).Output()
 	if err != nil {
 		return "" // detached HEAD or not a repo
 	}
@@ -25,7 +27,7 @@ func BranchName(p string) string {
 func DefaultBranch(p string) string {
 	dir := repoDir(p)
 	// origin/HEAD -> e.g. "origin/main"
-	if out, err := exec.Command("git", "-C", dir, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD").Output(); err == nil {
+	if out, err := procattr.Hide(exec.Command("git", "-C", dir, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")).Output(); err == nil {
 		ref := strings.TrimSpace(string(out))
 		if i := strings.LastIndexByte(ref, '/'); i >= 0 {
 			ref = ref[i+1:]
@@ -35,7 +37,7 @@ func DefaultBranch(p string) string {
 		}
 	}
 	for _, cand := range []string{"main", "master"} {
-		if err := exec.Command("git", "-C", dir, "rev-parse", "--verify", "--quiet", cand).Run(); err == nil {
+		if err := procattr.Hide(exec.Command("git", "-C", dir, "rev-parse", "--verify", "--quiet", cand)).Run(); err == nil {
 			return cand
 		}
 	}
@@ -47,7 +49,7 @@ func DefaultBranch(p string) string {
 // while editing: one session per (branch, HEAD) until the next commit advances HEAD.
 func HeadSHA(p string) string {
 	dir := repoDir(p)
-	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", dir, "rev-parse", "HEAD")).Output()
 	if err != nil {
 		return ""
 	}
@@ -62,7 +64,7 @@ func ParentCommitSHA(p, commitSHA string) string {
 		return ""
 	}
 	dir := repoDir(p)
-	out, err := exec.Command("git", "-C", dir, "rev-parse", commitSHA+"^").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", dir, "rev-parse", commitSHA+"^")).Output()
 	if err != nil {
 		return ""
 	}
@@ -77,7 +79,7 @@ func MergeBase(p, ref string) string {
 		return ""
 	}
 	dir := repoDir(p)
-	out, err := exec.Command("git", "-C", dir, "merge-base", ref, "HEAD").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", dir, "merge-base", ref, "HEAD")).Output()
 	if err != nil {
 		return ""
 	}
@@ -111,7 +113,7 @@ func InProgressRewrite(p string) bool {
 
 func anyMarker(p string, markers ...string) bool {
 	dir := repoDir(p)
-	gitDir, err := exec.Command("git", "-C", dir, "rev-parse", "--path-format=absolute", "--git-dir").Output()
+	gitDir, err := procattr.Hide(exec.Command("git", "-C", dir, "rev-parse", "--path-format=absolute", "--git-dir")).Output()
 	if err != nil {
 		return false
 	}
@@ -135,7 +137,7 @@ func anyMarker(p string, markers ...string) bool {
 // carry its AI attribution over.
 func CherryPickHead(p string) (sha string, ok bool) {
 	dir := repoDir(p)
-	gitDir, err := exec.Command("git", "-C", dir, "rev-parse", "--path-format=absolute", "--git-dir").Output()
+	gitDir, err := procattr.Hide(exec.Command("git", "-C", dir, "rev-parse", "--path-format=absolute", "--git-dir")).Output()
 	if err != nil {
 		return "", false
 	}

--- a/internal/gitutil/repoid.go
+++ b/internal/gitutil/repoid.go
@@ -4,6 +4,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // RepoID returns the canonical repository identifier for the file/dir at `p`.
@@ -32,7 +34,7 @@ func RepoID(p string) (string, bool) {
 		// AI edit is silently dropped → it falls to Human at commit.
 		dir = filepath.Dir(p)
 	}
-	out, err := exec.Command("git", "-C", dir, "rev-parse", "--path-format=absolute", "--git-common-dir").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", dir, "rev-parse", "--path-format=absolute", "--git-common-dir")).Output()
 	if err != nil {
 		return "", false
 	}
@@ -65,7 +67,7 @@ func Toplevel(p string) (string, bool) {
 		// absolute one (which wouldn't match `git diff` at commit → Human).
 		dir = filepath.Dir(p)
 	}
-	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel")).Output()
 	if err != nil {
 		return "", false
 	}

--- a/internal/gitutil/run.go
+++ b/internal/gitutil/run.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os/exec"
 	"time"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // DefaultTimeout bounds a git invocation made from long-running code — the daemon
@@ -27,7 +29,7 @@ const DefaultTimeout = 30 * time.Second
 const waitDelay = 5 * time.Second
 
 // Output runs `git -C dir args...` under DefaultTimeout and returns its stdout.
-// Drop-in for exec.Command("git", "-C", dir, ...).Output() in daemon-resident code.
+// Drop-in for procattr.Hide(exec.Command("git", "-C", dir, ...)).Output() in daemon-resident code.
 func Output(dir string, args ...string) ([]byte, error) {
 	return OutputTimeout(DefaultTimeout, dir, args...)
 }
@@ -44,7 +46,7 @@ func OutputTimeout(d time.Duration, dir string, args ...string) ([]byte, error) 
 // set up the command further (stdin, extra env) before running it; the context
 // kills the process, and WaitDelay keeps Wait from outliving it.
 func Command(ctx context.Context, dir string, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	cmd := procattr.Hide(exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...))
 	cmd.WaitDelay = waitDelay
 	return cmd
 }

--- a/internal/install/agent_windows.go
+++ b/internal/install/agent_windows.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 
 	"github.com/blamely/blamely/internal/config"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 const scheduledTaskName = "Blamely Daemon"
@@ -68,12 +70,6 @@ const (
 	legacyWatchdogTaskName = "Blamely Daemon Watchdog"
 )
 
-// createNoWindow (CREATE_NO_WINDOW) launches a console process with no console
-// window at all — the reliable way to start the console-subsystem blamely.exe
-// daemon without a cmd window flashing on screen. HideWindow alone is not
-// enough for console apps.
-const createNoWindow = 0x08000000
-
 var (
 	shell32           = syscall.NewLazyDLL("shell32.dll")
 	procIsUserAnAdmin = shell32.NewProc("IsUserAnAdmin")
@@ -118,7 +114,7 @@ func createOnLogonTask(binaryPath string) error {
 		"/SC", "ONLOGON",
 		"/RL", "LIMITED",
 	}
-	if out, err := exec.Command("schtasks", args...).CombinedOutput(); err != nil {
+	if out, err := procattr.Hide(exec.Command("schtasks", args...)).CombinedOutput(); err != nil {
 		return fmt.Errorf("schtasks /Create: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	allowBatteryStart(scheduledTaskName)
@@ -130,7 +126,7 @@ func installScheduledTask(binaryPath string) (string, error) {
 	// (e.g. an elevated session) can make /Create /F fail with "Access is
 	// denied" because the current user doesn't own it. Clear it first —
 	// best-effort, since a missing task also errors.
-	_ = exec.Command("schtasks", "/Delete", "/F", "/TN", scheduledTaskName).Run()
+	_ = procattr.Hide(exec.Command("schtasks", "/Delete", "/F", "/TN", scheduledTaskName)).Run()
 
 	if err := createOnLogonTask(binaryPath); err != nil {
 		return "", err
@@ -142,7 +138,7 @@ func installScheduledTask(binaryPath string) (string, error) {
 
 	// Kill any prior running instance so a reinstall picks up the new binary,
 	// then start the daemon now (hidden, via CREATE_NO_WINDOW). Both best-effort.
-	_ = exec.Command("schtasks", "/End", "/TN", scheduledTaskName).Run()
+	_ = procattr.Hide(exec.Command("schtasks", "/End", "/TN", scheduledTaskName)).Run()
 	_ = startDaemonNow(binaryPath)
 	return scheduledTaskName, nil
 }
@@ -174,7 +170,7 @@ func installUnprivilegedAgent(binaryPath string) (string, error) {
 func installKeepaliveTask(binaryPath string) error {
 	// Clear any stale task from a prior install under a different security
 	// context; a missing task also errors, so this is best-effort.
-	_ = exec.Command("schtasks", "/Delete", "/F", "/TN", keepaliveTaskName).Run()
+	_ = procattr.Hide(exec.Command("schtasks", "/Delete", "/F", "/TN", keepaliveTaskName)).Run()
 
 	args := []string{
 		"/Create", "/F",
@@ -184,7 +180,7 @@ func installKeepaliveTask(binaryPath string) error {
 		"/MO", fmt.Sprint(keepaliveMinutes),
 		"/RL", "LIMITED",
 	}
-	if out, err := exec.Command("schtasks", args...).CombinedOutput(); err != nil {
+	if out, err := procattr.Hide(exec.Command("schtasks", args...)).CombinedOutput(); err != nil {
 		return fmt.Errorf("schtasks /Create keepalive: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	allowBatteryStart(keepaliveTaskName)
@@ -220,11 +216,9 @@ func windowsStartupDir() (string, error) {
 // startDaemonNow launches the daemon for the current session with no console
 // window (CREATE_NO_WINDOW). HideWindow is kept as a belt-and-suspenders hint.
 func startDaemonNow(binaryPath string) error {
-	cmd := exec.Command(binaryPath, "daemon")
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		HideWindow:    true,
-		CreationFlags: createNoWindow,
-	}
+	// procattr.Hide is what supplies CREATE_NO_WINDOW here — the same flag every
+	// other subprocess now gets, rather than a second hand-rolled copy of it.
+	cmd := procattr.Hide(exec.Command(binaryPath, "daemon"))
 	if err := cmd.Start(); err != nil {
 		return err
 	}
@@ -244,7 +238,7 @@ func isSchtasksAccessDenied(err error) bool {
 
 // taskExists reports whether a Scheduled Task with the given name is registered.
 func taskExists(taskName string) bool {
-	return exec.Command("schtasks", "/Query", "/TN", taskName).Run() == nil
+	return procattr.Hide(exec.Command("schtasks", "/Query", "/TN", taskName)).Run() == nil
 }
 
 // EnsureDaemonAgent is the daemon's startup self-heal: it re-asserts the
@@ -326,7 +320,7 @@ func writeShortcut(lnkPath, target, args string) error {
 			"$s.WindowStyle=7;$s.Description='Blamely background service';$s.Save()",
 		lnkPath, target, args, filepath.Dir(target),
 	)
-	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).CombinedOutput()
+	out, err := procattr.Hide(exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("create startup shortcut: %w: %s", err, strings.TrimSpace(string(out)))
 	}
@@ -346,7 +340,7 @@ func removeLegacyAgentArtifacts() {
 	if dir, err := config.BlamelyDir(); err == nil {
 		_ = os.Remove(filepath.Join(dir, "bin", legacyStartupVBSName))
 	}
-	_ = exec.Command("schtasks", "/Delete", "/F", "/TN", legacyWatchdogTaskName).Run()
+	_ = procattr.Hide(exec.Command("schtasks", "/Delete", "/F", "/TN", legacyWatchdogTaskName)).Run()
 }
 
 func UninstallDaemonAgent() error {
@@ -356,8 +350,8 @@ func UninstallDaemonAgent() error {
 	}
 	// Remove the periodic keepalive. Best-effort: it won't exist on installs
 	// that predate it, and a missing task makes /Delete error.
-	_ = exec.Command("schtasks", "/Delete", "/F", "/TN", keepaliveTaskName).Run()
-	err := exec.Command("schtasks", "/Delete", "/F", "/TN", scheduledTaskName).Run()
+	_ = procattr.Hide(exec.Command("schtasks", "/Delete", "/F", "/TN", keepaliveTaskName)).Run()
+	err := procattr.Hide(exec.Command("schtasks", "/Delete", "/F", "/TN", scheduledTaskName)).Run()
 	if err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {

--- a/internal/install/bin_windows.go
+++ b/internal/install/bin_windows.go
@@ -8,7 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
-	"syscall"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // killProcess terminates a specific PID (and its child tree) on Windows by PID
@@ -18,7 +19,7 @@ import (
 // from the daemon's own PID file, never our own (killRunningDaemon guards
 // against pid == os.Getpid()). /T also reaps the daemon's child processes.
 func killProcess(pid int) error {
-	return exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(pid)).Run()
+	return procattr.Hide(exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(pid))).Run()
 }
 
 // killOtherDaemonProcesses synchronously kills every blamely.exe EXCEPT this
@@ -31,12 +32,13 @@ func killProcess(pid int) error {
 // running and kept the dir locked".
 func killOtherDaemonProcesses() {
 	self := "PID ne " + strconv.Itoa(os.Getpid())
-	_ = exec.Command("taskkill", "/F", "/T", "/IM", "blamely.exe", "/FI", self).Run()
+	_ = procattr.Hide(exec.Command("taskkill", "/F", "/T", "/IM", "blamely.exe", "/FI", self)).Run()
 }
 
-// detachedProcess is CREATE_NO_WINDOW | DETACHED_PROCESS so the cleanup shell
-// keeps running after this process (and its console) exits.
-const detachedProcess = 0x08000000 | 0x00000008
+// detachedProcess is DETACHED_PROCESS: the cleanup shell keeps running after
+// this process (and its console) exits. CREATE_NO_WINDOW comes from
+// procattr.Hide, which every subprocess goes through.
+const detachedProcess = 0x00000008
 
 // removeInstalledBinary cannot delete the currently-running blamely.exe
 // directly — Windows locks an executing image, so os.Remove fails with
@@ -134,15 +136,15 @@ func removeInstalledBinary(p string, extraFiles []string, purgeRoot string) erro
 		`ping 127.0.0.1 -n 2 >nul & %s & ping 127.0.0.1 -n 3 >nul & %s & ping 127.0.0.1 -n 3 >nul & %s`,
 		killClean, killClean, killClean,
 	)
-	cmd := exec.Command("cmd", "/c", script)
+	cmd := procattr.Hide(exec.Command("cmd", "/c", script))
 	// Run the cleanup from a directory OUTSIDE the tree being deleted, so the
 	// detached process's own working directory can never hold a lock that blocks
 	// the rmdir. (Inherited CWD could otherwise sit inside ~/.blamely.)
 	cmd.Dir = os.TempDir()
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		HideWindow:    true,
-		CreationFlags: detachedProcess,
-	}
+	// procattr.Hide already added CREATE_NO_WINDOW; this shell additionally needs
+	// DETACHED_PROCESS so it survives our own exit. OR it in rather than
+	// replacing SysProcAttr, which would drop what Hide set.
+	cmd.SysProcAttr.CreationFlags |= detachedProcess
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("schedule binary removal: %w", err)
 	}

--- a/internal/install/detect.go
+++ b/internal/install/detect.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 
 	"github.com/blamely/blamely/internal/config"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // Detected is the set of AI tools found on the current machine.
@@ -205,7 +207,7 @@ func detectCopilot() ToolPresence {
 
 	// `gh` extension list (last-resort).
 	if path, ok := lookPath("gh"); ok {
-		if out, err := exec.Command(path, "extension", "list").Output(); err == nil {
+		if out, err := procattr.Hide(exec.Command(path, "extension", "list")).Output(); err == nil {
 			if bytesContains(out, "copilot") {
 				hints = append(hints, path+" (gh copilot extension)")
 			}

--- a/internal/install/editorext.go
+++ b/internal/install/editorext.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // blamelyExtensionID is the publisher.name identifier for the Blamely extension,
@@ -130,7 +132,7 @@ func InstallEditorExtensions() []EditorExtensionResult {
 		// extracting — guarantees the install below always lands the downloaded build.
 		if wasPresent {
 			if exactID := installedExtensionID(cliPath, blamelyExtensionID); exactID != "" {
-				_ = exec.Command(cliPath, "--uninstall-extension", exactID).Run()
+				_ = procattr.Hide(exec.Command(cliPath, "--uninstall-extension", exactID)).Run()
 			}
 		}
 		out, err := installExtensionWithRetry(cliPath, source)
@@ -209,7 +211,7 @@ const signatureVerificationRetries = 3
 // combined output and error of the last attempt.
 func installExtensionWithRetry(cliPath, source string) ([]byte, error) {
 	run := func() ([]byte, error) {
-		return exec.Command(cliPath, "--install-extension", source, "--force").CombinedOutput()
+		return procattr.Hide(exec.Command(cliPath, "--install-extension", source, "--force")).CombinedOutput()
 	}
 	out, err := run()
 	for attempt := 0; attempt < signatureVerificationRetries; attempt++ {
@@ -282,7 +284,7 @@ func UninstallEditorExtensions(labels []string) error {
 		if exactID == "" {
 			continue
 		}
-		if err := exec.Command(cliPath, "--uninstall-extension", exactID).Run(); err != nil && firstErr == nil {
+		if err := procattr.Hide(exec.Command(cliPath, "--uninstall-extension", exactID)).Run(); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -324,7 +326,7 @@ func extensionInstalled(cliPath, id string) bool {
 // editor's own casing — which uninstall needs because `--uninstall-extension`
 // is case-sensitive on some Code-OSS forks.
 func installedExtensionID(cliPath, id string) string {
-	out, err := exec.Command(cliPath, "--list-extensions").Output()
+	out, err := procattr.Hide(exec.Command(cliPath, "--list-extensions")).Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/install/hookspath.go
+++ b/internal/install/hookspath.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/blamely/blamely/internal/config"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // InstallGitHook sets core.hooksPath to ~/.blamely/git-hooks (globally) and
@@ -76,8 +78,8 @@ func postCommitName() string {
 }
 
 // writePostCommitScript renders a small shell script that:
-//   1. Calls `blamely attribute <repo> <sha>` (best-effort, never blocks the commit).
-//   2. Chains to a repo-local .git/hooks/post-commit if one exists.
+//  1. Calls `blamely attribute <repo> <sha>` (best-effort, never blocks the commit).
+//  2. Chains to a repo-local .git/hooks/post-commit if one exists.
 func writePostCommitScript(path, binaryPath string) error {
 	// We resolve the repo via `git rev-parse --show-toplevel` inside the script
 	// so the same hook works for every repo on this machine.
@@ -282,7 +284,7 @@ func RemoveLegacyRepoHooks(repoRoot string) {
 // gitDirFor resolves the .git directory for repoRoot, handling worktrees and
 // submodules where .git is a file pointing elsewhere.
 func gitDirFor(repoRoot string) (string, error) {
-	out, err := exec.Command("git", "-C", repoRoot, "rev-parse", "--git-dir").Output()
+	out, err := procattr.Hide(exec.Command("git", "-C", repoRoot, "rev-parse", "--git-dir")).Output()
 	if err != nil {
 		return "", err
 	}
@@ -314,7 +316,7 @@ func isBlamelyManagedHook(path string) bool {
 }
 
 func readGlobalConfig(key string) (value string, present bool) {
-	out, err := exec.Command("git", "config", "--global", "--get", key).Output()
+	out, err := procattr.Hide(exec.Command("git", "config", "--global", "--get", key)).Output()
 	if err != nil {
 		// `git config --get` exits 1 when the key isn't set.
 		var ee *exec.ExitError
@@ -327,7 +329,7 @@ func readGlobalConfig(key string) (value string, present bool) {
 }
 
 func setGlobalConfig(key, value string) error {
-	cmd := exec.Command("git", "config", "--global", key, value)
+	cmd := procattr.Hide(exec.Command("git", "config", "--global", key, value))
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -337,7 +339,7 @@ func setGlobalConfig(key, value string) error {
 }
 
 func unsetGlobalConfig(key string) error {
-	cmd := exec.Command("git", "config", "--global", "--unset", key)
+	cmd := procattr.Hide(exec.Command("git", "config", "--global", "--unset", key))
 	// Exit code 5 = "no such variable" — fine.
 	if err := cmd.Run(); err != nil {
 		var ee *exec.ExitError

--- a/internal/install/lockcheck_windows.go
+++ b/internal/install/lockcheck_windows.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // editorImages are the Windows process images that keep Blamely's editor plugin
@@ -80,7 +82,7 @@ func runningBlockers() []blocker {
 // pidsByImage returns the PIDs of every running process with the given image
 // name, parsed from `tasklist` CSV output (no header row).
 func pidsByImage(image string) []int {
-	out, err := exec.Command("tasklist", "/FI", "IMAGENAME eq "+image, "/FO", "CSV", "/NH").Output()
+	out, err := procattr.Hide(exec.Command("tasklist", "/FI", "IMAGENAME eq "+image, "/FO", "CSV", "/NH")).Output()
 	if err != nil {
 		return nil
 	}

--- a/internal/install/update.go
+++ b/internal/install/update.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/blamely/blamely/internal/config"
+
+	"github.com/blamely/blamely/internal/procattr"
 )
 
 // Version is the running CLI version, assigned once at startup by cmd/blamely
@@ -104,7 +106,7 @@ type UpdateResult struct {
 //     the hand-off for a staged binary that had just run fine. See
 //     usableStdHandle in stdio_windows.go for the mechanism.
 var runInstaller = func(bin string, out io.Writer, args ...string) error {
-	cmd := exec.Command(bin, args...)
+	cmd := procattr.Hide(exec.Command(bin, args...))
 	// One writer value for both streams, deliberately: os/exec gives the child a
 	// single pipe when Stdout and Stderr are interface-equal, so the two streams
 	// interleave into one goroutine's writes. Assigning two separately-derived
@@ -701,7 +703,7 @@ func writeFileFrom(r io.Reader, dst string) error {
 func binaryVersion(ctx context.Context, bin string) (string, error) {
 	vctx, cancel := context.WithTimeout(ctx, updateSanityTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(vctx, bin, "--version").CombinedOutput()
+	out, err := procattr.Hide(exec.CommandContext(vctx, bin, "--version")).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
 	}

--- a/internal/procattr/procattr_other.go
+++ b/internal/procattr/procattr_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package procattr
+
+import "os/exec"
+
+// Hide is a no-op off Windows: only Windows gives a console-less parent's child
+// a console window of its own. See procattr_windows.go for what this exists for.
+func Hide(cmd *exec.Cmd) *exec.Cmd { return cmd }

--- a/internal/procattr/procattr_windows.go
+++ b/internal/procattr/procattr_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+// Package procattr keeps subprocesses from flashing a console window on
+// Windows.
+//
+// A process launched with CREATE_NO_WINDOW — which is how the daemon is started
+// (see install.startDaemonNow) — has no console of its own. When such a process
+// runs a CONSOLE program, Windows allocates a brand new console for the child
+// and shows it: a cmd window that pops up and vanishes. The daemon shells out to
+// git constantly (repo id, toplevel, branch, rev-parse on every hook event and
+// watcher signal), so the user sees a window flash over and over; uninstall adds
+// its own from taskkill, schtasks, tasklist and powershell.
+//
+// Passing CREATE_NO_WINDOW down to the child suppresses that console. It does
+// not affect output: stdout/stderr still go to whatever pipes the caller set up,
+// which is how every one of these call sites reads its result.
+package procattr
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// createNoWindow is CREATE_NO_WINDOW. Spelled out rather than imported so this
+// file needs nothing beyond syscall.
+const createNoWindow = 0x08000000
+
+// Hide marks cmd so the child gets no console window, and returns cmd so it can
+// wrap an exec.Command call inline. Any CreationFlags the caller already set are
+// preserved.
+func Hide(cmd *exec.Cmd) *exec.Cmd {
+	if cmd == nil {
+		return cmd
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= createNoWindow
+	return cmd
+}


### PR DESCRIPTION
A cmd window pops up and vanishes, repeatedly while the daemon runs and again during uninstall.

The daemon is started with CREATE_NO_WINDOW, so it has no console of its own. When a process in that state runs a CONSOLE program, Windows gives the child a brand new console and shows it. The daemon shells out to git constantly — repo id, toplevel, branch, rev-parse on every hook event and watcher signal — so the flash repeats for as long as it is running. Uninstall adds its own from taskkill, schtasks, tasklist and powershell.

Only two of the roughly sixty subprocess launches passed the flag down: startDaemonNow and the uninstall cleanup shell. Everything else inherited the default and got a console.

New internal/procattr wraps that decision in one place — Hide(cmd) on Windows, a no-op everywhere else — and every launch that can run from the daemon or from uninstall now goes through it: all of gitutil and gitnotes (the git calls), plus taskkill, schtasks, tasklist, powershell, the editor CLIs and the install hand-off. Output is unaffected; the flag suppresses the console, not the pipes these call sites read from.

The two places that already set SysProcAttr by hand now take the flag from Hide instead of carrying a second copy of the constant. The uninstall shell ORs in DETACHED_PROCESS rather than replacing SysProcAttr, which would have dropped what Hide set.

Verified by cross-compiling: build and vet pass for windows/amd64, windows/arm64, darwin/arm64 and linux/amd64. Not run on Windows.