### PR TITLE
Retry a failed auto-update, and say what the checker is doing

### DIFF
--- a/cmd/blamely/main.go
+++ b/cmd/blamely/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -137,6 +138,34 @@ func main() {
 	}
 }
 
+// logWriter forwards a child process's output into the standard logger, one
+// log line per output line, so the daemon's auto-update leaves the installer's
+// own messages in daemon.log instead of dropping them.
+//
+// Child output arrives in arbitrary chunks, not whole lines, so Write buffers
+// until a newline and logs complete lines only; CR is stripped so CRLF output
+// from a Windows installer doesn't leave a trailing \r in daemon.log. A final
+// unterminated line stays buffered — installer output ends with a newline, and
+// a truncated last line is not worth a Flush hook on an io.Writer.
+type logWriter struct {
+	buf []byte
+}
+
+func (w *logWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	for {
+		i := bytes.IndexByte(w.buf, '\n')
+		if i < 0 {
+			return len(p), nil
+		}
+		line := strings.TrimRight(string(w.buf[:i]), "\r")
+		w.buf = w.buf[i+1:]
+		if strings.TrimSpace(line) != "" {
+			log.Printf("update: %s", line)
+		}
+	}
+}
+
 func cmdDaemon() *cobra.Command {
 	var background bool
 	c := &cobra.Command{
@@ -205,6 +234,7 @@ func cmdDaemon() *cobra.Command {
 			// Hand the daemon its update check/apply as closures: internal/daemon
 			// cannot import internal/install (install imports daemon), so this is
 			// the same indirection the watcher lists above use.
+			daemon.CurrentVersion = install.Version
 			daemon.CheckUpdate = func(ctx context.Context) (updatehint.Hint, bool, error) {
 				rel, newer, err := install.CheckForUpdate(ctx, install.Version)
 				if err != nil {
@@ -214,7 +244,11 @@ func cmdDaemon() *cobra.Command {
 				return updatehint.Hint{Version: rel.Version, Tag: rel.Tag, URL: url}, newer, nil
 			}
 			daemon.ApplyUpdate = func(ctx context.Context) error {
-				_, err := install.Update(ctx, install.UpdateOptions{Current: install.Version, Out: io.Discard})
+				// Route the updater's own output — including the staged
+				// installer's stderr — into daemon.log. It used to be discarded,
+				// which left a failed auto-update reported as an exit status with
+				// no diagnosis anywhere on the machine.
+				_, err := install.Update(ctx, install.UpdateOptions{Current: install.Version, Out: &logWriter{}})
 				return err
 			}
 			return daemon.Run(cmd.Context())

--- a/internal/daemon/update.go
+++ b/internal/daemon/update.go
@@ -23,12 +23,33 @@ import (
 var (
 	CheckUpdate func(ctx context.Context) (updatehint.Hint, bool, error)
 	ApplyUpdate func(ctx context.Context) error
+	// CurrentVersion is the running build's version, for the log lines below.
+	// Assigned the same way and for the same reason: install.Version is not
+	// reachable from here.
+	CurrentVersion string
 )
 
 // updateCheckInitialDelay keeps the first check away from daemon startup, where
 // it would compete with the watchers coming up and with the installer's health
 // wait. A var so tests don't have to wait it out.
+//
+// This is also what converges a freshly installed machine: whatever release the
+// user's installer script happened to fetch, five minutes later the daemon pulls
+// the current one in the background.
 var updateCheckInitialDelay = 5 * time.Minute
+
+// updateRetryInterval is how soon a FAILED install is retried, instead of
+// waiting out the full check interval. That first post-install check is the one
+// that matters — a new machine should reach the current release while the user
+// is still at the keyboard — and a single transient failure (a half-written
+// download, a binary locked by an editor, a daemon mid-restart) used to push the
+// next attempt a whole day out. A var so tests don't have to wait it out.
+var updateRetryInterval = 30 * time.Minute
+
+// maxUpdateRetries bounds those quick retries. A genuinely broken install (wrong
+// arch, blocked by policy, no disk) settles back to the normal cadence instead
+// of re-downloading the release every half hour forever.
+const maxUpdateRetries = 2
 
 // watchForUpdates periodically asks whether a newer blamely exists, records the
 // answer as a hint for the CLI to surface, and — unless update.auto has been
@@ -40,61 +61,135 @@ var updateCheckInitialDelay = 5 * time.Minute
 // one that is up to date.
 func watchForUpdates(ctx context.Context) {
 	if CheckUpdate == nil {
+		log.Printf("update: checks unavailable (no updater wired in)")
 		return
 	}
+	// Say up front that the first check is coming and when. Until this line
+	// existed, a machine that was already up to date produced NO update output
+	// at all, so "did it ever check?" could not be answered from daemon.log —
+	// which is exactly how a failing auto-update read as one that never ran.
+	log.Printf("update: first check in %s, then every %dh",
+		updateCheckInitialDelay, config.LoadConfig().UpdateIntervalHours())
 	if !sleepCtx(ctx, updateCheckInitialDelay) {
 		return
 	}
+	retries := 0
 	for {
-		runUpdateCheck(ctx)
 		interval := time.Duration(config.LoadConfig().UpdateIntervalHours()) * time.Hour
+		// Only an install that ATTEMPTED and failed earns a short retry. An
+		// offline machine, a machine already up to date, and one with auto
+		// updates switched off all keep the normal cadence — being unable to
+		// reach the releases API is the steady state on a locked-down network,
+		// not something to poll harder about.
+		if runUpdateCheck(ctx) == installFailed && retries < maxUpdateRetries {
+			retries++
+			interval = updateRetryInterval
+		} else {
+			retries = 0
+		}
+		log.Printf("update: next check in %s", interval)
 		if !sleepCtx(ctx, interval) {
 			return
 		}
 	}
 }
 
-func runUpdateCheck(ctx context.Context) {
-	if updateCheckDisabled() {
-		return
+// updateOutcome is what one check round did, as far as the retry policy cares.
+type updateOutcome int
+
+const (
+	// checkSettled covers every round that should wait out the normal interval:
+	// up to date, unreachable, auto-install disabled, or installed fine.
+	checkSettled updateOutcome = iota
+	// installFailed means a newer release was found and the install of it
+	// failed — the one case worth retrying sooner.
+	installFailed
+)
+
+func runUpdateCheck(ctx context.Context) updateOutcome {
+	// CheckUpdate is a package var assigned by cmd/blamely; guard it here as
+	// well as at the top of watchForUpdates, symmetrically with ApplyUpdate
+	// below, so no caller of this function can nil-deref.
+	if CheckUpdate == nil {
+		return checkSettled
 	}
+	if reason := updateCheckDisabledReason(); reason != "" {
+		log.Printf("update: checks disabled (%s)", reason)
+		return checkSettled
+	}
+	log.Printf("update: checking now (current %s, channel %s)",
+		versionLabel(), channelLabel())
 	hint, newer, err := CheckUpdate(ctx)
 	if err != nil {
 		// One line per interval, at most. An unreachable releases API is the
 		// normal state on a locked-down corporate network, not an incident.
-		log.Printf("update check: %v", err)
-		return
+		log.Printf("update: check failed: %v", err)
+		return checkSettled
 	}
 	if !newer {
+		log.Printf("update: up to date (%s)", versionLabel())
 		_ = updatehint.Clear()
-		return
+		return checkSettled
 	}
 	hint.CheckedAt = time.Now()
 	if err := updatehint.Write(hint); err != nil {
-		log.Printf("update check: record hint: %v", err)
+		log.Printf("update: recording the hint failed: %v", err)
 	}
 	if !config.LoadConfig().Update.Auto || ApplyUpdate == nil {
-		log.Printf("update available: %s (run `blamely update` to install)", hint.Version)
-		return
+		log.Printf("update: %s available — auto-install is off, run `blamely update`", hint.Version)
+		return checkSettled
 	}
-	log.Printf("update available: %s — installing", hint.Version)
+	log.Printf("update: %s available — installing in the background", hint.Version)
 	if err := ApplyUpdate(ctx); err != nil {
-		log.Printf("update install failed: %v", err)
-		return
+		log.Printf("update: installing %s failed: %v", hint.Version, err)
+		return installFailed
 	}
+	log.Printf("update: %s installed (the daemon is restarted by the installer)", hint.Version)
 	// The new binary is in place; the hint no longer describes anything the user
 	// needs to act on. (This process is about to be restarted by the installer.)
 	_ = updatehint.Clear()
+	return checkSettled
 }
 
-// updateCheckDisabled mirrors install.UpdateCheckDisabled. It re-reads the env
-// and config here rather than calling that function because of the import cycle
-// described on CheckUpdate above.
-func updateCheckDisabled() bool {
-	if v := strings.TrimSpace(os.Getenv("BLAMELY_NO_UPDATE_CHECK")); v != "" && v != "0" {
-		return true
+// versionLabel is CurrentVersion, or a placeholder when cmd/blamely did not set
+// it (only reachable from a test or an embedder).
+func versionLabel() string {
+	if strings.TrimSpace(CurrentVersion) == "" {
+		return "unknown"
 	}
-	return !config.LoadConfig().Update.Check
+	return CurrentVersion
+}
+
+// channelLabel names the release channel the check will use, resolved the same
+// way install.UpdateChannel resolves it — repeated here rather than called for
+// the import-cycle reason described on CheckUpdate.
+func channelLabel() string {
+	if v := strings.TrimSpace(os.Getenv("BLAMELY_CHANNEL")); v != "" {
+		return v
+	}
+	if c := strings.TrimSpace(config.LoadConfig().Update.Channel); c != "" {
+		return c
+	}
+	return "latest"
+}
+
+// updateCheckDisabledReason mirrors install.UpdateCheckDisabled. It re-reads
+// the env and config here rather than calling that function because of the
+// import cycle described on CheckUpdate above.
+//
+// It names what turned checking off — the env var or the config key — so the
+// log can say which one, or "" when checks are on.
+// Fleets disable checks via `blamely config set update.check off`, and a log
+// line blaming BLAMELY_NO_UPDATE_CHECK would send whoever reads it to the
+// wrong knob.
+func updateCheckDisabledReason() string {
+	if v := strings.TrimSpace(os.Getenv("BLAMELY_NO_UPDATE_CHECK")); v != "" && v != "0" {
+		return "BLAMELY_NO_UPDATE_CHECK"
+	}
+	if !config.LoadConfig().Update.Check {
+		return "update.check off"
+	}
+	return ""
 }
 
 // sleepCtx waits for d, returning false if the context is cancelled first.

--- a/internal/daemon/update_test.go
+++ b/internal/daemon/update_test.go
@@ -1,8 +1,13 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"log"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,9 +23,12 @@ func pinUpdateHooks(t *testing.T,
 ) {
 	t.Helper()
 	prevCheck, prevApply, prevDelay := CheckUpdate, ApplyUpdate, updateCheckInitialDelay
+	prevRetry := updateRetryInterval
 	CheckUpdate, ApplyUpdate, updateCheckInitialDelay = check, apply, time.Millisecond
+	updateRetryInterval = time.Millisecond
 	t.Cleanup(func() {
 		CheckUpdate, ApplyUpdate, updateCheckInitialDelay = prevCheck, prevApply, prevDelay
+		updateRetryInterval = prevRetry
 	})
 }
 
@@ -167,4 +175,211 @@ func TestRunUpdateCheck_DisabledByEnvKillSwitch(t *testing.T) {
 		nil,
 	)
 	runUpdateCheck(context.Background())
+}
+
+// stopWatcher cancels the watcher and waits for it to actually return. Leaving
+// it running past the test is not harmless: t.Cleanup then restores CheckUpdate
+// to nil underneath a loop that calls it, panicking the whole package.
+func stopWatcher(t *testing.T, cancel context.CancelFunc, done <-chan struct{}) {
+	t.Helper()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchForUpdates did not stop after its context was cancelled")
+	}
+}
+
+// TestWatchForUpdates_FirstCheckConvergesFreshInstall pins down the behaviour a
+// fresh machine depends on: whatever release the installer script fetched, the
+// daemon reaches the current one on its own shortly after startup — no user
+// action, no waiting out the 24h cadence.
+func TestWatchForUpdates_FirstCheckConvergesFreshInstall(t *testing.T) {
+	fakeHome(t)
+	applied := make(chan struct{}, 1)
+	pinUpdateHooks(t,
+		func(ctx context.Context) (updatehint.Hint, bool, error) {
+			return updatehint.Hint{Version: "1.8.1", Tag: "v1.8.1"}, true, nil
+		},
+		func(ctx context.Context) error {
+			select {
+			case applied <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { watchForUpdates(ctx); close(done) }()
+	defer stopWatcher(t, cancel, done)
+
+	select {
+	case <-applied:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a newer release was available and never installed")
+	}
+}
+
+// TestWatchForUpdates_RetriesAfterFailedInstall is the regression guard for the
+// gap this exposed: the check found a newer release, the install failed, and the
+// loop then slept the FULL interval — so one transient failure on a fresh
+// machine left it on the old version for a day.
+func TestWatchForUpdates_RetriesAfterFailedInstall(t *testing.T) {
+	fakeHome(t)
+	attempts := make(chan int, maxUpdateRetries+2)
+	var n int
+	var mu sync.Mutex
+	pinUpdateHooks(t,
+		func(ctx context.Context) (updatehint.Hint, bool, error) {
+			return updatehint.Hint{Version: "1.8.1", Tag: "v1.8.1"}, true, nil
+		},
+		func(ctx context.Context) error {
+			mu.Lock()
+			n++
+			cur := n
+			mu.Unlock()
+			select {
+			case attempts <- cur:
+			default:
+			}
+			return errors.New("fork/exec: the request is not supported")
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { watchForUpdates(ctx); close(done) }()
+	defer stopWatcher(t, cancel, done)
+
+	// A second attempt proves the failure shortened the wait: the configured
+	// interval is 24h, so without the retry path nothing else would run.
+	deadline := time.After(2 * time.Second)
+	seen := 0
+	for seen < 2 {
+		select {
+		case <-attempts:
+			seen++
+		case <-deadline:
+			t.Fatalf("only %d install attempt(s); a failed install must be retried", seen)
+		}
+	}
+}
+
+// TestWatchForUpdates_RetriesAreBounded keeps a permanently broken install from
+// re-downloading the release every retry interval forever: after maxUpdateRetries
+// consecutive failures the loop must fall back to the normal cadence.
+func TestWatchForUpdates_RetriesAreBounded(t *testing.T) {
+	fakeHome(t)
+	var mu sync.Mutex
+	var n int
+	pinUpdateHooks(t,
+		func(ctx context.Context) (updatehint.Hint, bool, error) {
+			return updatehint.Hint{Version: "1.8.1", Tag: "v1.8.1"}, true, nil
+		},
+		func(ctx context.Context) error {
+			mu.Lock()
+			n++
+			mu.Unlock()
+			return errors.New("still broken")
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { watchForUpdates(ctx); close(done) }()
+	defer stopWatcher(t, cancel, done)
+
+	// With a 1ms retry interval, an unbounded loop would run away; the bound
+	// caps it at the initial attempt plus maxUpdateRetries before the 24h sleep.
+	time.Sleep(300 * time.Millisecond)
+	mu.Lock()
+	got := n
+	mu.Unlock()
+	if got > 1+maxUpdateRetries {
+		t.Errorf("%d install attempts; want at most %d before falling back to the normal interval", got, 1+maxUpdateRetries)
+	}
+	if got < 2 {
+		t.Errorf("%d install attempts; the failure should have been retried at least once", got)
+	}
+}
+
+// TestWatchForUpdates_LogsTheSchedule is the answer to "did it ever check?".
+// Before these lines a machine that was already up to date wrote NOTHING about
+// updates to daemon.log, so a failed auto-update and a check that never ran
+// looked identical from the outside.
+func TestWatchForUpdates_LogsTheSchedule(t *testing.T) {
+	fakeHome(t)
+	var buf syncBuffer
+	restore := pinLogOutput(t, &buf)
+	defer restore()
+
+	CurrentVersion = "1.8.0"
+	t.Cleanup(func() { CurrentVersion = "" })
+
+	checked := make(chan struct{}, 1)
+	pinUpdateHooks(t,
+		func(ctx context.Context) (updatehint.Hint, bool, error) {
+			select {
+			case checked <- struct{}{}:
+			default:
+			}
+			return updatehint.Hint{}, false, nil // up to date
+		},
+		func(ctx context.Context) error {
+			t.Error("nothing to install when already up to date")
+			return nil
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { watchForUpdates(ctx); close(done) }()
+	select {
+	case <-checked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the check never ran")
+	}
+	// Let the post-check lines land before cancelling.
+	time.Sleep(50 * time.Millisecond)
+	stopWatcher(t, cancel, done)
+
+	got := buf.String()
+	for _, want := range []string{
+		"update: first check in",
+		"update: checking now (current 1.8.0, channel latest)",
+		"update: up to date (1.8.0)",
+		"update: next check in",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("daemon log missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// syncBuffer is a bytes.Buffer safe for the logger's goroutine and the test's.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// pinLogOutput captures log output for one test.
+func pinLogOutput(t *testing.T, w io.Writer) func() {
+	t.Helper()
+	prev := log.Writer()
+	log.SetOutput(w)
+	return func() { log.SetOutput(prev) }
 }


### PR DESCRIPTION
Two gaps the Windows failure exposed, both in the daemon's checker.

A failed install used to cost a full day. The loop ran the check, then slept the configured interval — 24h by default — whatever had happened, so one transient failure on a fresh machine left it on the old version until the next day. A failed INSTALL now retries after 30 minutes, at most twice before falling back to the normal cadence; every other outcome keeps it. Being unable to reach the releases API is the steady state on a locked-down network, not something to poll harder about, so only an attempted-and-failed install shortens the wait.

The checker was also silent. It logged on error, and when an update was available — so a machine that was up to date wrote nothing at all about updates, and "did the five-minute check ever run?" could not be answered from daemon.log. That is precisely how a failing auto-update read as one that never ran. It now logs the schedule it is keeping (first check in 5m0s, then every 24h; next check in ...), that a check is starting, and every outcome including "up to date". All twelve lines share one `update:` prefix so the whole story greps out in one go.

The daemon cannot import internal/install, so the running version arrives as CurrentVersion alongside the existing CheckUpdate/ApplyUpdate hooks. The updater's output — including the staged installer's stderr — now goes to daemon.log instead of io.Discard, which is what left the reported failure with an exit status and no diagnosis anywhere on the machine.